### PR TITLE
Fixes columns view when there is only one column

### DIFF
--- a/src/pwa/stores/router/context.js
+++ b/src/pwa/stores/router/context.js
@@ -55,7 +55,11 @@ const Context = types
       ) {
         // WARNING - temporal fix, should be removed after refactoring
         self.rawColumns[i].items; // eslint-disable-line
-        if (self.rawColumns[i].items.length === 0) break;
+        if (
+          i >= self.rawColumns.length ||
+          self.rawColumns[i].items.length === 0
+        )
+          break;
         columns[i] = self.rawColumns[i];
       }
       return columns.filter(column => column.items.length > 0);


### PR DESCRIPTION
fixes https://github.com/frontity/wp-org-connection/issues/55